### PR TITLE
Fix Jest coverage paths: collectCoverageFrom reaches up from src/test…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "rootDir": "src/test",
     "collectCoverage": true,
     "collectCoverageFrom": [
-      "src/**/*.{js,jsx}"
+      "../**/*.{js,jsx}",
+      "!../src/test/**",
+      "!../node_modules/**"
     ],
     "testEnvironment": "node"
   }


### PR DESCRIPTION
… to include src files